### PR TITLE
Use 'status' instead 'code'

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -1145,7 +1145,7 @@ var errSerializer = Logger.stdSerializers.err = function (err) {
         message: err.message,
         name: err.name,
         stack: getFullErrorStack(err),
-        code: err.code,
+        status: err.status,
         signal: err.signal
     }
     return obj;


### PR DESCRIPTION
Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.